### PR TITLE
Add support for ACF version 5 (pro)

### DIFF
--- a/acf-button.php
+++ b/acf-button.php
@@ -30,6 +30,13 @@ class acf_field_button_plugin
 		load_textdomain( $domain, $mofile );
 		*/
 		
+		$version = get_option( 'acf_version' );
+
+		if( $version[0] === '5' ) {
+			// version 5 (pro)
+			add_action('acf/init', array($this, 'register_fields'));
+			return;
+		}	
 		
 		// version 4+
 		add_action('acf/register_fields', array($this, 'register_fields'));	


### PR DESCRIPTION
Check's the version of ACF and uses the 'acf_init' action hook instead pf 'acf/register_fields' hook as this hook does not exist in the pro version.